### PR TITLE
Adds support for librarian-puppet dependency resolution

### DIFF
--- a/acceptance-test.sh
+++ b/acceptance-test.sh
@@ -14,10 +14,12 @@ PID=$!
 
 if [ ! -f $ROOT_PATH/puppetlabs-apache-1.5.0.tar.gz 2>&1 >/dev/null ]; then
 	wget -q https://forgeapi.puppetlabs.com/v3/files/puppetlabs-apache-1.5.0.tar.gz -O $ROOT_PATH/puppetlabs-apache-1.5.0.tar.gz >/dev/null
+	wget -q https://forgeapi.puppetlabs.com/v3/files/puppetlabs-apache-1.10.0.tar.gz -O $ROOT_PATH/puppetlabs-apache-1.10.0.tar.gz >/dev/null
 	wget -q https://forgeapi.puppetlabs.com/v3/files/puppetlabs-concat-1.2.3.tar.gz -O $ROOT_PATH/puppetlabs-concat-1.2.3.tar.gz >/dev/null
 	wget -q https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.6.0.tar.gz -O $ROOT_PATH/puppetlabs-stdlib-4.6.0.tar.gz >/dev/null
 fi
 curl -s -X PUT http://localhost:8080/admin/module/puppetlabs-apache-1.5.0.tar.gz -T $ROOT_PATH/puppetlabs-apache-1.5.0.tar.gz >/dev/null
+curl -s -X PUT http://localhost:8080/admin/module/puppetlabs-apache-1.10.0.tar.gz -T $ROOT_PATH/puppetlabs-apache-1.10.0.tar.gz >/dev/null
 curl -s -X PUT http://localhost:8080/admin/module/puppetlabs-concat-1.2.3.tar.gz -T $ROOT_PATH/puppetlabs-concat-1.2.3.tar.gz >/dev/null
 curl -s -X PUT http://localhost:8080/admin/module/puppetlabs-stdlib-4.6.0.tar.gz -T $ROOT_PATH/puppetlabs-stdlib-4.6.0.tar.gz >/dev/null
 

--- a/api/client.go
+++ b/api/client.go
@@ -69,6 +69,62 @@ func (c *AnvilClient) GetReleaseByModule(user string, module string) (*Response,
 	return entity, err
 }
 
+//get data about a particular user-module
+func (c *AnvilClient) GetModulesByUserModule(user string, module string) (*ModuleResult, error) {
+	var entity *ModuleResult
+
+	url := fmt.Sprintf("http://%s/v3/modules/%s-%s", c.Address, user, module)
+
+	req, err := http.NewRequest("GET", url, nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return entity, nil
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return entity, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return entity, processErrors(body, resp.StatusCode)
+	}
+	err = json.Unmarshal(body, &entity)
+	return entity, err
+}
+
+//get data about a particular release
+func (c *AnvilClient) GetReleaseByUserModuleVersion(user string, module string, version string) (*Result, error) {
+	var entity *Result
+
+	url := fmt.Sprintf("http://%s/v3/releases/%s-%s-%s", c.Address, user, module, version)
+
+	req, err := http.NewRequest("GET", url, nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return entity, nil
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return entity, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return entity, processErrors(body, resp.StatusCode)
+	}
+	err = json.Unmarshal(body, &entity)
+	return entity, err
+}
+
 func processErrors(body []byte, code int) error {
 	var e *ErrorResponse
 

--- a/api/forge_api.go
+++ b/api/forge_api.go
@@ -18,6 +18,50 @@ type Result struct {
 	Md5      string `json:"file_md5"`
 	Metadata `json:"metadata"`
 }
+
+type Owner struct {
+	Uri      string `json:"uri"`
+	Slug     string `json:"slug"`
+	Username string `json:"username"`
+}
+
+type CurrentRelease struct {
+	Uri               string `json:"uri"`
+	Slug              string `json:"slug"`
+	ModuleAbbreviated `json:"module"`
+	Metadata          `json:"metadata"`
+}
+
+type ModuleAbbreviated struct {
+	Uri   string `json:"uri"`
+	Slug  string `json:"slug"`
+	Name  string `json:"name"`
+	Owner `json:"owner"`
+}
+
+type ModuleResult struct {
+	Uri            string `json:"uri"`
+	Slug           string `json:"slug"`
+	Name           string `json:"name"`
+	Owner          `json:"owner"`
+	CurrentRelease `json:"current_release"`
+	FileUri        string    `json:"file_uri"`
+	Version        string    `json:"version"`
+	Md5            string    `json:"file_md5"`
+	Releases       []Release `json:"releases"`
+}
+
+type Release struct {
+	Uri       string  `json:"uri"`
+	Slug      string  `json:"slug"`
+	FileUri   string  `json:"file_uri"`
+	Version   string  `json:"version"`
+	Deleted   *string `json:"deleted_at"`
+	Created   *string `json:"created_at"`
+	Supported *string `json:"supported"`
+	FileSize  *string `json:"file_size"`
+}
+
 type Pagination struct {
 	Next bool `json:"next"`
 }

--- a/component_test.go
+++ b/component_test.go
@@ -30,6 +30,7 @@ func (s *ComponentTestSuite) SetUpSuite(c *C) {
 	os.MkdirAll(s.path+"/modules", 0755)
 	if _, err := os.Stat(s.path + "/puppetlabs-apache-1.5.0.tar.gz"); err != nil {
 		dl("https://forgeapi.puppetlabs.com/v3/files/puppetlabs-apache-1.5.0.tar.gz", s.path+"/puppetlabs-apache-1.5.0.tar.gz")
+		dl("https://forgeapi.puppetlabs.com/v3/files/puppetlabs-apache-1.10.0.tar.gz", s.path+"/puppetlabs-apache-1.10.0.tar.gz")
 		dl("https://forgeapi.puppetlabs.com/v3/files/puppetlabs-concat-1.2.3.tar.gz", s.path+"/puppetlabs-concat-1.2.3.tar.gz")
 		dl("https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.6.0.tar.gz", s.path+"/puppetlabs-stdlib-4.6.0.tar.gz")
 	}
@@ -136,4 +137,63 @@ func (s *ComponentTestSuite) TestDownloadFile(c *C) {
 
 	c.Assert(err, Equals, nil)
 	c.Assert(found, Equals, expected)
+}
+
+// client should return releases for a module
+func (s *ComponentTestSuite) TestGetModulesByUserModule(c *C) {
+	// given
+	file := s.path + "/puppetlabs-apache-1.5.0.tar.gz"
+	f, _ := os.Open(file)
+	defer f.Close()
+	loc, _ := s.client.PublishModule(f, "puppetlabs-apache-1.5.0.tar.gz")
+
+	// when
+	resp, err := s.client.GetModulesByUserModule("puppetlabs", "apache")
+
+	// then
+	c.Assert(err, Equals, nil)
+	c.Assert(resp.Releases[0].FileUri, Equals, loc)
+	c.Assert(resp.Releases[0].Version, Equals, "1.5.0")
+}
+
+// client should return data for a particular release
+func (s *ComponentTestSuite) TestGetReleaseByUserModuleVersion(c *C) {
+	// given
+	file := s.path + "/puppetlabs-apache-1.5.0.tar.gz"
+	f, _ := os.Open(file)
+	defer f.Close()
+	loc, _ := s.client.PublishModule(f, "puppetlabs-apache-1.5.0.tar.gz")
+
+	// when
+	resp, err := s.client.GetReleaseByUserModuleVersion("puppetlabs", "apache", "1.5.0")
+
+	// then
+	c.Assert(err, Equals, nil)
+	c.Assert(resp.FileUri, Equals, loc)
+	c.Assert(resp.Version, Equals, "1.5.0")
+	c.Assert(resp.Metadata.Name, Equals, "puppetlabs-apache")
+}
+
+// client should return most recent release
+func (s *ComponentTestSuite) TestGetModulesByUserModuleLatest(c *C) {
+	// given
+	file1 := s.path + "/puppetlabs-apache-1.5.0.tar.gz"
+	f1, _ := os.Open(file1)
+	defer f1.Close()
+	loc1, _ := s.client.PublishModule(f1, "puppetlabs-apache-1.5.0.tar.gz")
+
+	file2 := s.path + "/puppetlabs-apache-1.10.0.tar.gz"
+	f2, _ := os.Open(file2)
+	defer f2.Close()
+	loc2, _ := s.client.PublishModule(f2, "puppetlabs-apache-1.10.0.tar.gz")
+
+	// when
+	resp, err := s.client.GetModulesByUserModule("puppetlabs", "apache")
+
+	// then
+	c.Assert(err, Equals, nil)
+	c.Assert(resp.Releases[0].FileUri, Equals, loc2)
+	c.Assert(resp.Releases[0].Version, Equals, "1.10.0")
+	c.Assert(resp.Releases[1].FileUri, Equals, loc1)
+	c.Assert(resp.Releases[1].Version, Equals, "1.5.0")
 }

--- a/service/forge_resource.go
+++ b/service/forge_resource.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/jhaals/puppet-anvil/api"
+	"github.com/pmylund/sortutil"
 )
 
 // Handlers that implement the Forge API
@@ -48,6 +49,28 @@ func (f *ForgeResource) GetReleases(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// Query modules, filter by user supplied query
+func (f *ForgeResource) GetModules(w http.ResponseWriter, r *http.Request) {
+	user, mod, err := parseQueryGetParam(r)
+	if err != nil {
+		setBadRequestResponse(w, err)
+		return
+	}
+
+	results, err := f.getResults(user, mod)
+
+	response := &api.Response{
+		Pagination: api.Pagination{
+			Next: false, // nil?
+		},
+		Results: results,
+	}
+
+	if err := setOKResponse(w, response); err != nil {
+		setInternalServerErrorResponse(w, err)
+	}
+}
+
 func (f *ForgeResource) getResults(user string, mod string) ([]api.Result, error) {
 	results := make([]api.Result, 0)
 
@@ -70,9 +93,143 @@ func (f *ForgeResource) getResult(metadata api.Metadata, path string) (api.Resul
 		return api.Result{}, fmt.Errorf("not a module")
 	}
 	return api.Result{
-		Uri:      fmt.Sprintf("/v3/release/%s/%s", metadata.Name, metadata.Version),
+		Uri:      fmt.Sprintf("/v3/releases/%s/%s", metadata.Name, metadata.Version),
 		Version:  metadata.Version,
 		FileUri:  fmt.Sprintf("/v3/files/%s", path),
+		Md5:      checksum,
+		Metadata: metadata,
+	}, nil
+}
+
+// Get all info about a module
+func (f *ForgeResource) GetModuleInfo(w http.ResponseWriter, r *http.Request) {
+	user, mod, err := parseUserModulePathParam(r)
+	if err != nil {
+		setBadRequestResponse(w, err)
+		return
+	}
+
+	results, err := f.getModuleResult(user, mod)
+
+	response := results
+
+	if err := setOKResponse(w, response); err != nil {
+		setInternalServerErrorResponse(w, err)
+	}
+}
+
+func (f *ForgeResource) getModuleResult(user string, mod string) (api.ModuleResult, error) {
+	var err error
+	var result api.ModuleResult
+	releases := make([]api.Release, 0)
+
+	//get metadata for given user-modules
+	modules := ListModules(filepath.Join(f.ModulePath, user, mod))
+	if len(modules) == 0 {
+		log.Println("list of modules is empty")
+		return result, err
+	}
+
+	//sort the list of modules and get most recent version
+	sortutil.DescByField(modules, "Version")
+	v := modules[0].Version
+	n := modules[0].Name
+	m := modules[0]
+
+	//get path and md5 of most recent version
+	path := filepath.Join(user, mod, user+"-"+mod+"-"+v+".tar.gz")
+	checksum, err := Checksum(filepath.Join(f.ModulePath, path))
+	if err != nil {
+		log.Println(err)
+		return api.ModuleResult{}, fmt.Errorf("Could not get md5 of module")
+	}
+
+	//builds the releases array
+	for _, metadata := range modules {
+		path := filepath.Join(user, mod, user+"-"+mod+"-"+metadata.Version+".tar.gz")
+		release, err := f.getReleaseFromMetaData(metadata, path)
+		if err == nil {
+			releases = append(releases, release)
+		}
+	}
+
+	return api.ModuleResult{
+		Uri:      fmt.Sprintf("/v3/modules/%s", n),
+		Slug:     user + "-" + mod,
+		Name:     n,
+		FileUri:  fmt.Sprintf("/v3/files/%s", path),
+		Version:  v,
+		Md5:      checksum,
+		Releases: releases,
+		Owner: api.Owner{
+			Uri:      fmt.Sprintf("/v3/users/%s", user),
+			Slug:     user,
+			Username: user,
+		},
+		CurrentRelease: api.CurrentRelease{
+			Uri:      fmt.Sprintf("/v3/releases/%s-%s-%s", user, mod, v),
+			Slug:     user + "-" + mod + "-" + v,
+			Metadata: m,
+			ModuleAbbreviated: api.ModuleAbbreviated{
+				Uri:  fmt.Sprintf("/v3/users/%s", user),
+				Slug: user + "-" + mod,
+				Name: mod,
+				Owner: api.Owner{
+					Uri:      fmt.Sprintf("/v3/users/%s", user),
+					Slug:     user,
+					Username: user,
+				},
+			},
+		},
+	}, nil
+}
+
+func (f *ForgeResource) getReleaseFromMetaData(metadata api.Metadata, path string) (api.Release, error) {
+	return api.Release{
+		Uri:     fmt.Sprintf("/v3/releases/%s-%s", metadata.Name, metadata.Version),
+		FileUri: fmt.Sprintf("/v3/files/%s", path),
+		Version: metadata.Version,
+		Slug:    metadata.Name + "-" + metadata.Version,
+	}, nil
+}
+
+// Get information about a given release
+func (f *ForgeResource) GetReleaseInfo(w http.ResponseWriter, r *http.Request) {
+	user, mod, version, err := parseReleasePathParam(r)
+	if err != nil {
+		setBadRequestResponse(w, err)
+		return
+	}
+
+	results, err := f.getReleaseResult(user, mod, version)
+
+	response := results
+
+	if err := setOKResponse(w, response); err != nil {
+		setInternalServerErrorResponse(w, err)
+	}
+}
+
+// Get information about a given release
+func (f *ForgeResource) getReleaseResult(user string, mod string, version string) (api.Result, error) {
+	pathToFile := filepath.Join(f.ModulePath, user, mod)
+	file := user + "-" + mod + "-" + version + ".tar.gz"
+	checksum, err := Checksum(filepath.Join(pathToFile, file))
+	if err != nil {
+		log.Println(err)
+		return api.Result{}, fmt.Errorf("Could not get md5 of module")
+	}
+
+	metadata, err := GetModuleMetadata(pathToFile, file)
+	if err != nil {
+		log.Println(err)
+		return api.Result{}, fmt.Errorf("Could not retrieve metadata for module")
+	}
+
+	return api.Result{
+		Uri:      fmt.Sprintf("/v3/releases/%s-%s-%s", user, mod, version),
+		Version:  version,
+		FileUri:  fmt.Sprintf("/v3/files/%s/%s/%s", user, mod, file),
 		Md5:      checksum,
 		Metadata: metadata,
 	}, nil

--- a/service/forge_resource.go
+++ b/service/forge_resource.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"path/filepath"
 
+	"github.com/as/structslice"
 	"github.com/jhaals/puppet-anvil/api"
-	"github.com/pmylund/sortutil"
 )
 
 // Handlers that implement the Forge API
@@ -131,7 +131,7 @@ func (f *ForgeResource) getModuleResult(user string, mod string) (api.ModuleResu
 	}
 
 	//sort the list of modules and get most recent version
-	sortutil.DescByField(modules, "Version")
+	structslice.SortByName(modules, "Version")
 	v := modules[0].Version
 	n := modules[0].Name
 	m := modules[0]

--- a/service/module.go
+++ b/service/module.go
@@ -41,6 +41,26 @@ func ListModules(path string) []api.Metadata {
 	return result
 }
 
+// Get metadata for a single module
+func GetModuleMetadata(path string, filename string) (api.Metadata, error) {
+	var metadata api.Metadata
+	file, err := os.Stat(filepath.Join(path, filename))
+	if err != nil {
+		log.Println(err)
+		return metadata, err
+	}
+
+	err = ExtractMetadata(file, path)
+	if err != nil {
+		log.Println(err)
+	}
+	metadata, err = readMetadata(filepath.Join(path, file.Name()+".metadata"))
+	if err != nil {
+		log.Println(err)
+	}
+	return metadata, err
+}
+
 //Extract metadata from module
 func ExtractMetadata(module os.FileInfo, path string) error {
 	moduleFile := filepath.Join(path, module.Name())

--- a/service/service.go
+++ b/service/service.go
@@ -36,6 +36,9 @@ func (s *AnvilService) Run() error {
 	mr := mux.NewRouter()
 	mr.HandleFunc("/v3/files/{user}/{module}/{fileName}", forge.GetModule).Methods("GET")
 	mr.HandleFunc("/v3/releases", forge.GetReleases).Methods("GET")
+	mr.HandleFunc("/v3/releases/{user-module-version}", forge.GetReleaseInfo).Methods("GET")
+	mr.HandleFunc("/v3/modules", forge.GetModules).Methods("GET")
+	mr.HandleFunc("/v3/modules/{user-module}", forge.GetModuleInfo).Methods("GET")
 	mr.HandleFunc("/admin/module/{fileName}", admin.UpsertFile).Methods("PUT")
 
 	http.Handle("/", handlers.LoggingHandler(os.Stdout, mr))

--- a/service/user_input.go
+++ b/service/user_input.go
@@ -14,12 +14,26 @@ func parseFileNamePathParam(r *http.Request) (string, string, string, error) {
 	return user, mod, fileName, err
 }
 
+func parseUserModulePathParam(r *http.Request) (string, string, error) {
+	userModule := mux.Vars(r)["user-module"]
+	user, mod, err := parseModuleName(userModule)
+	return user, mod, err
+}
+
 func parseModuleGetParam(r *http.Request) (string, string, error) {
 	moduleName := r.URL.Query().Get("module")
 	if len(moduleName) == 0 {
 		return "", "", fmt.Errorf("GET param 'module' empty")
 	}
 	return parseModuleName(moduleName)
+}
+
+func parseQueryGetParam(r *http.Request) (string, string, error) {
+	queryName := r.URL.Query().Get("query")
+	if len(queryName) == 0 {
+		return "", "", fmt.Errorf("GET param 'query' empty")
+	}
+	return parseModuleName(queryName)
 }
 func parseFileName(fileName string) (string, string, error) {
 	if !strings.HasSuffix(fileName, ".tar.gz") {
@@ -42,4 +56,16 @@ func parseModuleName(moduleName string) (string, string, error) {
 	mod := strings.Split(moduleName, "-")[1]
 
 	return user, mod, nil
+}
+
+func parseReleasePathParam(r *http.Request) (string, string, string, error) {
+	userModuleVersion := mux.Vars(r)["user-module-version"]
+	if strings.Count(userModuleVersion, "-") != 2 {
+		return "", "", "", fmt.Errorf("user-module-version '%s' should be of the form '{user}-{module}-{version}", userModuleVersion)
+	}
+	user := strings.Split(userModuleVersion, "-")[0]
+	mod := strings.Split(userModuleVersion, "-")[1]
+	version := strings.Split(userModuleVersion, "-")[2]
+
+	return user, mod, version, nil
 }


### PR DESCRIPTION
Hi, sorry for the rather large PR. This adds support for librarian-puppet, which appears to use the `/modules/<user>-<module>` and `/releases/<user>-<module>-<version>` endpoints in order to work out dependency resolution.

With this PR, I've been able to get librarian-puppet (v2.2.3) to work. R10k and puppet module install , also still work.

Let me know if I can make any additional changes to get this merged.

Thanks!
Paul
