### PR TITLE
Uses hashicorp/go-version for version comparison

### DIFF
--- a/acceptance-test.sh
+++ b/acceptance-test.sh
@@ -15,11 +15,13 @@ PID=$!
 if [ ! -f $ROOT_PATH/puppetlabs-apache-1.5.0.tar.gz 2>&1 >/dev/null ]; then
 	wget -q https://forgeapi.puppetlabs.com/v3/files/puppetlabs-apache-1.5.0.tar.gz -O $ROOT_PATH/puppetlabs-apache-1.5.0.tar.gz >/dev/null
 	wget -q https://forgeapi.puppetlabs.com/v3/files/puppetlabs-apache-1.10.0.tar.gz -O $ROOT_PATH/puppetlabs-apache-1.10.0.tar.gz >/dev/null
+	wget -q https://forgeapi.puppetlabs.com/v3/files/puppetlabs-apache-1.0.0.tar.gz -O $ROOT_PATH/puppetlabs-apache-1.0.0.tar.gz >/dev/null
 	wget -q https://forgeapi.puppetlabs.com/v3/files/puppetlabs-concat-1.2.3.tar.gz -O $ROOT_PATH/puppetlabs-concat-1.2.3.tar.gz >/dev/null
 	wget -q https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.6.0.tar.gz -O $ROOT_PATH/puppetlabs-stdlib-4.6.0.tar.gz >/dev/null
 fi
 curl -s -X PUT http://localhost:8080/admin/module/puppetlabs-apache-1.5.0.tar.gz -T $ROOT_PATH/puppetlabs-apache-1.5.0.tar.gz >/dev/null
 curl -s -X PUT http://localhost:8080/admin/module/puppetlabs-apache-1.10.0.tar.gz -T $ROOT_PATH/puppetlabs-apache-1.10.0.tar.gz >/dev/null
+curl -s -X PUT http://localhost:8080/admin/module/puppetlabs-apache-1.0.0.tar.gz -T $ROOT_PATH/puppetlabs-apache-1.0.0.tar.gz >/dev/null
 curl -s -X PUT http://localhost:8080/admin/module/puppetlabs-concat-1.2.3.tar.gz -T $ROOT_PATH/puppetlabs-concat-1.2.3.tar.gz >/dev/null
 curl -s -X PUT http://localhost:8080/admin/module/puppetlabs-stdlib-4.6.0.tar.gz -T $ROOT_PATH/puppetlabs-stdlib-4.6.0.tar.gz >/dev/null
 

--- a/component_test.go
+++ b/component_test.go
@@ -31,6 +31,7 @@ func (s *ComponentTestSuite) SetUpSuite(c *C) {
 	if _, err := os.Stat(s.path + "/puppetlabs-apache-1.5.0.tar.gz"); err != nil {
 		dl("https://forgeapi.puppetlabs.com/v3/files/puppetlabs-apache-1.5.0.tar.gz", s.path+"/puppetlabs-apache-1.5.0.tar.gz")
 		dl("https://forgeapi.puppetlabs.com/v3/files/puppetlabs-apache-1.10.0.tar.gz", s.path+"/puppetlabs-apache-1.10.0.tar.gz")
+		dl("https://forgeapi.puppetlabs.com/v3/files/puppetlabs-apache-1.0.0.tar.gz", s.path+"/puppetlabs-apache-1.0.0.tar.gz")
 		dl("https://forgeapi.puppetlabs.com/v3/files/puppetlabs-concat-1.2.3.tar.gz", s.path+"/puppetlabs-concat-1.2.3.tar.gz")
 		dl("https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.6.0.tar.gz", s.path+"/puppetlabs-stdlib-4.6.0.tar.gz")
 	}
@@ -177,23 +178,27 @@ func (s *ComponentTestSuite) TestGetReleaseByUserModuleVersion(c *C) {
 // client should return most recent release
 func (s *ComponentTestSuite) TestGetModulesByUserModuleLatest(c *C) {
 	// given
-	file1 := s.path + "/puppetlabs-apache-1.5.0.tar.gz"
+	file1 := s.path + "/puppetlabs-apache-1.0.0.tar.gz"
 	f1, _ := os.Open(file1)
 	defer f1.Close()
-	loc1, _ := s.client.PublishModule(f1, "puppetlabs-apache-1.5.0.tar.gz")
+	s.client.PublishModule(f1, "puppetlabs-apache-1.0.0.tar.gz")
 
-	file2 := s.path + "/puppetlabs-apache-1.10.0.tar.gz"
+	file2 := s.path + "/puppetlabs-apache-1.5.0.tar.gz"
 	f2, _ := os.Open(file2)
 	defer f2.Close()
-	loc2, _ := s.client.PublishModule(f2, "puppetlabs-apache-1.10.0.tar.gz")
+	s.client.PublishModule(f2, "puppetlabs-apache-1.5.0.tar.gz")
+
+	file3 := s.path + "/puppetlabs-apache-1.10.0.tar.gz"
+	f3, _ := os.Open(file3)
+	defer f3.Close()
+	loc3, _ := s.client.PublishModule(f3, "puppetlabs-apache-1.10.0.tar.gz")
 
 	// when
 	resp, err := s.client.GetModulesByUserModule("puppetlabs", "apache")
 
 	// then
 	c.Assert(err, Equals, nil)
-	c.Assert(resp.Releases[0].FileUri, Equals, loc2)
-	c.Assert(resp.Releases[0].Version, Equals, "1.10.0")
-	c.Assert(resp.Releases[1].FileUri, Equals, loc1)
-	c.Assert(resp.Releases[1].Version, Equals, "1.5.0")
+	c.Assert(resp.FileUri, Equals, loc3)
+	c.Assert(resp.Version, Equals, "1.10.0")
+	c.Assert(resp.CurrentRelease.Metadata.Version, Equals, "1.10.0")
 }


### PR DESCRIPTION
It turns out my sorting solution was a bit "naive". I've switched to using hashicorp/go-version to do the version comparison, which appears to do a much better job. For example, it understands that 1.10.0 is newer than 1.5.0 whereas the previous solution did not.

This is my first crack at implementing the sort.Interface, so I'd be interested in feedback if you think there's a better way to get this done. However, it appears to work and I've added a test case which failed in the previous solution, but works with this one.

Thanks!
Paul
